### PR TITLE
Pluto source/sink block failures and appveyor update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
     - 7z x swigwin-3.0.8.zip > nul
 
     # Install Flex / Bison
-    - appveyor DownloadFile http://downloads.sourceforge.net/project/winflexbison/win_flex_bison-2.5.6.zip
+    - appveyor DownloadFile https://sourceforge.net/projects/winflexbison/files/old_versions/win_flex_bison-2.5.6.zip
     - 7z x win_flex_bison-2.5.6.zip > nul
 
     # Install libvolk

--- a/include/gnuradio/iio/pluto_sink.h
+++ b/include/gnuradio/iio/pluto_sink.h
@@ -26,7 +26,8 @@
 #include <gnuradio/iio/api.h>
 #include <gnuradio/hier_block2.h>
 
-namespace gr::iio {
+namespace gr {
+  namespace iio {
 	/*!
 	 * \brief Sink block for the PlutoSDR
 	 * \ingroup iio
@@ -47,6 +48,8 @@ namespace gr::iio {
 				double attenuation,
 				const char *filter = "");
 	};
-}
+
+        } // namespace iio
+} // namespace gr
 
 #endif /* INCLUDED_IIO_PLUTO_SINK_H */

--- a/lib/pluto_sink_impl.cc
+++ b/lib/pluto_sink_impl.cc
@@ -24,7 +24,8 @@
 
 #include <iio.h>
 
-using namespace gr::iio;
+namespace gr {
+  namespace iio {
 
 pluto_sink::sptr pluto_sink::make(const std::string& uri,
 		unsigned long long frequency,
@@ -54,3 +55,6 @@ pluto_sink_impl::pluto_sink_impl(fmcomms2_sink::sptr block) :
 	fmcomms2_sink_f32c(true, false, block)
 {
 }
+
+        } // namespace iio
+} // namespace gr

--- a/lib/pluto_sink_impl.h
+++ b/lib/pluto_sink_impl.h
@@ -30,7 +30,8 @@
 
 #include "device_sink_impl.h"
 
-namespace gr::iio {
+namespace gr {
+  namespace iio {
 
 	class pluto_sink_impl : public pluto_sink
 				, public fmcomms2_sink_f32c
@@ -39,6 +40,7 @@ namespace gr::iio {
 		explicit pluto_sink_impl(fmcomms2_sink::sptr block);
 	};
 
-} // namespace gr::iio
+        } // namespace iio
+} // namespace gr
 
-#endif /* INCLUDED_IIO_FMCOMMS2_SINK_IMPL_H */
+#endif /* INCLUDED_PLUTO_SINK_IMPL_H */

--- a/lib/pluto_source_impl.cc
+++ b/lib/pluto_source_impl.cc
@@ -24,7 +24,8 @@
 #include <iio.h>
 #include <stdio.h>
 
-using namespace gr::iio;
+namespace gr {
+  namespace iio {
 
 pluto_source::sptr pluto_source::make(const std::string& uri,
 		unsigned long long frequency, unsigned long samplerate,
@@ -90,3 +91,6 @@ pluto_source_impl::pluto_source_impl(fmcomms2_source::sptr block) :
 	fmcomms2_source_f32c(true, false, block)
 {
 }
+
+        } // namespace iio
+} // namespace gr


### PR DESCRIPTION
This PR includes updates to the new Pluto source and sink blocks, which now allow them to build.  These changes follow the gnuradio convention for namespace syntax.  Also included is an update to the appveyor configuration to fix a bison/flex download issue.