### PR TITLE
XML: Updated category values to sort blocks in GRC

### DIFF
--- a/grc/iio_device_sink.xml
+++ b/grc/iio_device_sink.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>IIO Device Sink</name>
 	<key>iio_device_sink</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.device_sink($uri, $device, $channels, $device_phy, $params, $buffer_size, $interpolation - 1, $cyclic)</make>

--- a/grc/iio_device_source.xml
+++ b/grc/iio_device_source.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>IIO Device Source</name>
 	<key>iio_device_source</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.device_source($uri, $device, $channels, $device_phy, $params, $buffer_size, $decimation - 1)</make>

--- a/grc/iio_fmcomms2_sink.xml
+++ b/grc/iio_fmcomms2_sink.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>FMComms2/3/4 Sink</name>
 	<key>iio_fmcomms2_sink</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.fmcomms2_sink_f32c($uri, $frequency, $samplerate, $interpolation - 1, $bandwidth, $tx1_en, $tx2_en, $buffer_size, $cyclic, $rf_port_select, $attenuation1, $attenuation2, $filter, $auto_filter)</make>

--- a/grc/iio_fmcomms2_source.xml
+++ b/grc/iio_fmcomms2_source.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>FMComms2/3/4 Source</name>
 	<key>iio_fmcomms2_source</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.fmcomms2_source_f32c($uri, $frequency, $samplerate, $decimation - 1, $bandwidth, $rx1_en, $rx2_en, $buffer_size, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $rf_port_select, $filter, $auto_filter)</make>

--- a/grc/iio_fmcomms5_sink.xml
+++ b/grc/iio_fmcomms5_sink.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>FMComms5 Sink</name>
 	<key>iio_fmcomms5_sink</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.fmcomms5_sink_f32c($uri, $frequency1, $frequency2, $samplerate, $interpolation - 1, $bandwidth, $ch1_en, $ch2_en, $ch3_en, $ch4_en, $buffer_size, $cyclic, $rf_port_select, $attenuation1, $attenuation2, $attenuation3, $attenuation4, $filter)</make>

--- a/grc/iio_fmcomms5_source.xml
+++ b/grc/iio_fmcomms5_source.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>FMComms5 Source</name>
 	<key>iio_fmcomms5_source</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.fmcomms5_source_f32c($uri, $frequency1, $frequency2, $samplerate, $decimation - 1, $bandwidth, $ch1_en, $ch2_en, $ch3_en, $ch4_en, $buffer_size, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $gain3, $manual_gain3, $gain4, $manual_gain4, $rf_port_select, $filter)</make>

--- a/grc/iio_math.xml
+++ b/grc/iio_math.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>Function</name>
 	<key>math</key>
-	<category>Math Operators</category>
+	<category>[Industrial IO]/Math Operators</category>
 	<import>from gnuradio import iio</import>
 	<make>iio.iio_math($function, $num_inputs)</make>
 

--- a/grc/iio_math_gen.xml
+++ b/grc/iio_math_gen.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>Function Generator</name>
 	<key>math_gen</key>
-	<category>Waveform Generators</category>
+	<category>[Industrial IO]/Waveform Generators</category>
 	<import>from gnuradio import iio</import>
 	<make>iio.iio_math_gen($samp_rate, $wav_freq, $function)</make>
 

--- a/grc/iio_modulo_const_ff.xml
+++ b/grc/iio_modulo_const_ff.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>Modulo Const</name>
 	<key>iio_modulo_const_ff</key>
-	<category>Math Operators</category>
+	<category>[Industrial IO]/Math Operators</category>
 	<import>from gnuradio import iio</import>
 	<make>iio.modulo_const_ff($modulo, $vlen)</make>
 	<param>

--- a/grc/iio_modulo_ff.xml
+++ b/grc/iio_modulo_ff.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>Modulo</name>
 	<key>iio_modulo_ff</key>
-	<category>Math Operators</category>
+	<category>[Industrial IO]/Math Operators</category>
 	<import>from gnuradio import iio</import>
 	<make>iio.modulo_ff($vlen)</make>
 	<param>

--- a/grc/iio_pluto_sink.xml
+++ b/grc/iio_pluto_sink.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>PlutoSDR Sink</name>
 	<key>pluto_sink</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]/PlutoSDR</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.pluto_sink($uri, $frequency, $samplerate, $interpolation - 1, $bandwidth, $buffer_size, $cyclic, $attenuation, $filter, $auto_filter)</make>

--- a/grc/iio_pluto_source.xml
+++ b/grc/iio_pluto_source.xml
@@ -2,7 +2,7 @@
 <block>
 	<name>PlutoSDR Source</name>
 	<key>pluto_source</key>
-	<category>Industrial IO</category>
+	<category>[Industrial IO]/PlutoSDR</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
 	<make>iio.pluto_source($uri, $frequency, $samplerate, $decimation - 1, $bandwidth, $buffer_size, $quadrature, $rfdc, $bbdc, $gain, $manual_gain, $filter, $auto_filter)</make>

--- a/grc/iio_power_ff.xml
+++ b/grc/iio_power_ff.xml
@@ -8,7 +8,7 @@
 <block>
 	<name>Power</name>
 	<key>iio_power_ff</key>
-	<category>Math Operators</category>
+	<category>[Industrial IO]/Math Operators</category>
 	<import>from gnuradio import iio</import>
 	<make>iio.power_ff($vlen)</make>
 	<param>


### PR DESCRIPTION
Previously blocks were shown in the "(no module specified)" category.
Adding a root module value groups the blocks correctly. Additional
sub-categories were defined for FMComms, PlutoSDR, etc.