### PR TITLE
lib/iio_math: Make sure the connection is done on the required port.

### DIFF
--- a/lib/iio_math_gen_impl.cc
+++ b/lib/iio_math_gen_impl.cc
@@ -63,7 +63,7 @@ gr::basic_block_sptr iio_math_gen_impl::get_src_block()
 	return src_block;
 }
 
-void iio_math_gen_impl::connect_to_output(gr::basic_block_sptr block)
+void iio_math_gen_impl::connect_to_output(gr::basic_block_sptr block, unsigned int port)
 {
 	basic_block_sptr hier = shared_from_this();
 

--- a/lib/iio_math_impl.cc
+++ b/lib/iio_math_impl.cc
@@ -131,15 +131,14 @@ gr::basic_block_sptr iio_math_impl::get_src_block()
 	return shared_from_this();
 }
 
-void iio_math_impl::connect_to_output(gr::basic_block_sptr block)
+void iio_math_impl::connect_to_output(gr::basic_block_sptr block, unsigned int port)
 {
 	basic_block_sptr hier = shared_from_this();
 
 	if (hier == block) {
 		blocks::copy::sptr copy = blocks::copy::make(sizeof(float));
-
 		/* Handle 'y = x' expression */
-		connect(hier, 0, copy, 0);
+		connect(hier, port, copy, 0);
 		connect(copy, 0, hier, 0);
 	} else {
 		connect(block, 0, hier, 0);
@@ -299,7 +298,7 @@ void connect_to_output(void *pdata, void *_block)
 	struct iio_math_impl::block *block = (struct iio_math_impl::block *) _block;
 	iio_math_impl *m = (iio_math_impl *) pdata;
 
-	m->connect_to_output(block->sptr);
+	m->connect_to_output(block->sptr, block->port);
 }
 
 void delete_block(void *pdata, void *_block)

--- a/lib/iio_math_impl.h
+++ b/lib/iio_math_impl.h
@@ -48,7 +48,7 @@ namespace gr {
 			void register_block(struct block *block);
 			void set_port_used(unsigned int port);
 			virtual gr::basic_block_sptr get_src_block();
-			virtual void connect_to_output(gr::basic_block_sptr block);
+			virtual void connect_to_output(gr::basic_block_sptr block, unsigned int port = 0);
 
 		private:
 			std::vector<struct block *> blocks;
@@ -71,7 +71,7 @@ namespace gr {
 					const std::string &function);
 
 			virtual gr::basic_block_sptr get_src_block();
-			virtual void connect_to_output(gr::basic_block_sptr block);
+			virtual void connect_to_output(gr::basic_block_sptr block, unsigned int port = 0);
 
 		private:
 			gr::basic_block_sptr src_block;


### PR DESCRIPTION
For an expression of type y = x0 (or x1), the connections are
done properly only for port 0, given that this is the default. When trying
to create(or start) a source block for port 1, the flow throws a runtime error,
because there are no internal connections to that port.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>