### PR TITLE
Context closure bug

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,11 @@ install:
     - appveyor-retry nuget install boost_thread-vc120 -Version 1.61.0
 
     # Install libiio
-    - appveyor DownloadFile https://ci.appveyor.com/api/projects/analogdevicesinc/libiio/artifacts/libiio-win64.zip?branch=master
-    - 7z x libiio-win64.zip > nul
+    - appveyor DownloadFile https://ci.appveyor.com/api/projects/analogdevicesinc/libiio/artifacts/libiio.zip?branch=master
+    - 7z x libiio*.zip > nul
+    - mkdir libiio-win64
+    - mv libiio-*/MS64/* libiio-win64/
+    - mv libiio-*/include/* libiio-win64/
 
     # Install libad9361
     - appveyor DownloadFile https://ci.appveyor.com/api/projects/analogdevicesinc/libad9361-iio/artifacts/libad9361-win64.zip?branch=master

--- a/lib/device_sink_impl.cc
+++ b/lib/device_sink_impl.cc
@@ -148,8 +148,7 @@ namespace gr {
     device_sink_impl::~device_sink_impl()
     {
 	    iio_buffer_destroy(buf);
-	    if (destroy_ctx)
-		    iio_context_destroy(ctx);
+           device_source_impl::remove_ctx_history(ctx,destroy_ctx);
     }
 
     void

--- a/lib/device_source_impl.cc
+++ b/lib/device_source_impl.cc
@@ -232,19 +232,21 @@ namespace gr {
     }
 
     void device_source_impl::remove_ctx_history(struct iio_context *ctx_from_block,
-          bool destroy_ctx)
+                           bool destroy_ctx)
     {
+      boost::lock_guard<boost::mutex> lock(ctx_mutex);
+
       for(ctx_it it = contexts.begin(); it != contexts.end(); ++it) {
-          if (it->ctx == ctx_from_block) {
-              if (it->count==1){
-                  if (destroy_ctx)
-                    iio_context_destroy(ctx_from_block);
-                  it = contexts.erase(it);
-                  return;
-              }
-              else
-                  it->count--;
+        if (it->ctx == ctx_from_block) {
+          if (it->count==1) {
+            if (destroy_ctx)
+              iio_context_destroy(ctx_from_block);
+            it = contexts.erase(it);
+            return;
           }
+          else
+            it->count--;
+        }
       }
     }
 

--- a/lib/device_source_impl.cc
+++ b/lib/device_source_impl.cc
@@ -231,22 +231,33 @@ namespace gr {
 	    message_port_register_out(port_id);
     }
 
+    void device_source_impl::remove_ctx_history(struct iio_context *ctx_from_block,
+          bool destroy_ctx)
+    {
+      for(ctx_it it = contexts.begin(); it != contexts.end(); ++it) {
+          if (it->ctx == ctx_from_block) {
+              if (it->count==1){
+                  if (destroy_ctx)
+                    iio_context_destroy(ctx_from_block);
+                  it = contexts.erase(it);
+                  return;
+              }
+              else
+                  it->count--;
+          }
+      }
+    }
+
+
+
     /*
      * Our virtual destructor.
      */
     device_source_impl::~device_source_impl()
     {
             // Make sure this is the last open block with a given context
-            if (destroy_ctx) {
-                for(ctx_it it = contexts.begin(); it != contexts.end(); ++it) {
-                    if (it->ctx == ctx) {
-                        if (it->count==1)
-                            iio_context_destroy(ctx);
-                        else
-                            it->count--;
-                    }
-                }
-            }
+            // before removing the context
+            remove_ctx_history(ctx,destroy_ctx);
     }
 
     void

--- a/lib/device_source_impl.cc
+++ b/lib/device_source_impl.cc
@@ -131,12 +131,14 @@ namespace gr {
     {
 	    struct iio_context *ctx;
 	    unsigned short vid, pid;
-	    std::map<std::string,struct iio_context *>::iterator it;
 
 	    // Check if we have a context with the same URI open
-	    if (!contexts.empty()){
-	    	it = contexts.find(uri);
-	        if (it != contexts.end()) return it->second;
+	    if (!contexts.empty()) {
+                    for(ctx_it it = contexts.begin(); it != contexts.end(); ++it) {
+		        if (it->uri.compare(uri)==0) {
+		            it->count++; return it->ctx;
+		        }
+		   }
 	    }
 
 	    if (uri.empty()) {
@@ -152,7 +154,8 @@ namespace gr {
 			    ctx = iio_create_network_context(uri.c_str());
 	    }
 	    // Save context info for future checks
-	    contexts[uri] = ctx;
+           ctxInfo ci = {.uri=uri,.ctx=ctx,.count=1};
+           contexts.push_back(ci);
 
 	    return ctx;
     }
@@ -233,8 +236,17 @@ namespace gr {
      */
     device_source_impl::~device_source_impl()
     {
-	    if (destroy_ctx)
-		    iio_context_destroy(ctx);
+            // Make sure this is the last open block with a given context
+            if (destroy_ctx) {
+                for(ctx_it it = contexts.begin(); it != contexts.end(); ++it) {
+                    if (it->ctx == ctx) {
+                        if (it->count==1)
+                            iio_context_destroy(ctx);
+                        else
+                            it->count--;
+                    }
+                }
+            }
     }
 
     void

--- a/lib/device_source_impl.cc
+++ b/lib/device_source_impl.cc
@@ -154,7 +154,7 @@ namespace gr {
 			    ctx = iio_create_network_context(uri.c_str());
 	    }
 	    // Save context info for future checks
-           ctxInfo ci = {.uri=uri,.ctx=ctx,.count=1};
+           ctxInfo ci = {uri, ctx, 1};
            contexts.push_back(ci);
 
 	    return ctx;

--- a/lib/device_source_impl.h
+++ b/lib/device_source_impl.h
@@ -34,6 +34,7 @@ namespace gr {
 
     struct ctxInfo{std::string uri; struct iio_context * ctx; int count;};
     static std::vector<ctxInfo> contexts;
+    static boost::mutex ctx_mutex;
 
     typedef std::vector<ctxInfo>::iterator ctx_it;
 

--- a/lib/device_source_impl.h
+++ b/lib/device_source_impl.h
@@ -91,6 +91,8 @@ namespace gr {
       bool start();
       bool stop();
 
+      static void remove_ctx_history(struct iio_context *ctx, bool destroy_ctx);
+
       static struct iio_context * get_context(const std::string &uri);
       static bool load_fir_filter(std::string &filter, struct iio_device *phy);
     };

--- a/lib/device_source_impl.h
+++ b/lib/device_source_impl.h
@@ -24,7 +24,6 @@
 
 #include <string>
 #include <vector>
-#include <map>
 
 #include <iio.h>
 #include <boost/thread.hpp>
@@ -33,7 +32,10 @@
 namespace gr {
   namespace iio {
 
-    static std::map<std::string,struct iio_context *> contexts;
+    struct ctxInfo{std::string uri; struct iio_context * ctx; int count;};
+    static std::vector<ctxInfo> contexts;
+
+    typedef std::vector<ctxInfo>::iterator ctx_it;
 
     class device_source_impl : public device_source
     {


### PR DESCRIPTION
This fixes #20 as well as fixes an appveyor build issue.  Now we keep track of all open contexts, the number of blocks using each context, and their uris.

This came about from an issue: https://ez.analog.com/thread/103178-runtimeerror-unable-to-create-buffer-16-after-added-fmcomms2-blocks-on-no-gui-run-to-completion-gnuradio