### PR TITLE
Gain set mode

### DIFF
--- a/grc/iio_fmcomms2_source.xml
+++ b/grc/iio_fmcomms2_source.xml
@@ -115,6 +115,7 @@
 		<key>manual_gain1</key>
 		<value>64.0</value>
 		<type>real</type>
+		<hide>#if $gain1() == '"manual"' then 'none' else 'all'#</hide>
 	</param>
 
 	<param>
@@ -144,6 +145,7 @@
 		<key>manual_gain2</key>
 		<value>64.0</value>
 		<type>real</type>
+		<hide>#if $gain2() == '"manual"' then 'none' else 'all'#</hide>
 	</param>
 
 	<param>

--- a/grc/iio_fmcomms5_source.xml
+++ b/grc/iio_fmcomms5_source.xml
@@ -140,6 +140,7 @@
 		<key>manual_gain1</key>
 		<value>64.0</value>
 		<type>real</type>
+		<hide>#if $gain1() == '"manual"' then 'none' else 'all'#</hide>
 	</param>
 
 	<param>
@@ -169,6 +170,7 @@
 		<key>manual_gain2</key>
 		<value>64.0</value>
 		<type>real</type>
+		<hide>#if $gain2() == '"manual"' then 'none' else 'all'#</hide>
 	</param>
 
 	<param>
@@ -198,6 +200,7 @@
 		<key>manual_gain3</key>
 		<value>64.0</value>
 		<type>real</type>
+		<hide>#if $gain3() == '"manual"' then 'none' else 'all'#</hide>
 	</param>
 
 	<param>
@@ -227,6 +230,7 @@
 		<key>manual_gain4</key>
 		<value>64.0</value>
 		<type>real</type>
+		<hide>#if $gain4() == '"manual"' then 'none' else 'all'#</hide>
 	</param>
 
 	<param>

--- a/grc/iio_pluto_source.xml
+++ b/grc/iio_pluto_source.xml
@@ -97,6 +97,7 @@
 		<key>manual_gain</key>
 		<value>64.0</value>
 		<type>real</type>
+		<hide>#if $gain() == '"manual"' then 'none' else 'all'#</hide>
 	</param>
 
 	<param>

--- a/lib/fmcomms2_source_impl.cc
+++ b/lib/fmcomms2_source_impl.cc
@@ -170,16 +170,21 @@ namespace gr {
 			    boost::to_string(rfdc));
 	    params.push_back("in_voltage_bb_dc_offset_tracking_en=" +
 			    boost::to_string(bbdc));
+	    std::string gain1_str = boost::to_string(gain1);
 	    params.push_back("in_voltage0_gain_control_mode=" +
-			    boost::to_string(gain1));
-	    params.push_back("in_voltage0_hardwaregain=" +
+			    gain1_str);
+	    if (gain1_str.compare("manual") == 0) {
+	            params.push_back("in_voltage0_hardwaregain=" +
 			    boost::to_string(gain1_value));
-
+	    }
 	    if (!is_fmcomms4) {
+		    std::string gain2_str = boost::to_string(gain2);
 		    params.push_back("in_voltage1_gain_control_mode=" +
-				    boost::to_string(gain2));
-		    params.push_back("in_voltage1_hardwaregain=" +
-				    boost::to_string(gain2_value));
+				    gain2_str);
+		    if (gain2_str.compare("manual") == 0) {
+			    params.push_back("in_voltage1_hardwaregain=" +
+					    boost::to_string(gain2_value));
+	            }
 	    }
 
 	    params.push_back("in_voltage0_rf_port_select=" +


### PR DESCRIPTION
This PR fixes #18 and hides gain dialog on blocks when either Fast, Slow, or Hybrid AGC modes are selected.