### PR TITLE
lib/device_source_impl: Fix sample counter variable type.

### DIFF
--- a/lib/device_source_impl.cc
+++ b/lib/device_source_impl.cc
@@ -369,7 +369,7 @@ namespace gr {
 		if (!byte_offset) {
 			tag_t tag;
 			tag.value = pmt::from_long(items_in_buffer);
-			tag.offset = sample_counter;
+			tag.offset = nitems_written(i);
 			tag.key = pmt::intern("buffer_start");
 			tag.srcid = alias_pmt();
 
@@ -377,7 +377,6 @@ namespace gr {
 		}
 	}
 
-	sample_counter += items;
 	items_in_buffer -= items;
 	byte_offset += items * iio_buffer_step(buf);
 
@@ -388,7 +387,6 @@ namespace gr {
     {
 	boost::unique_lock<boost::mutex> lock(iio_mutex);
 
-	sample_counter = 0;
 	items_in_buffer = 0;
 	please_refill_buffer = false;
 	thread_stopped = false;

--- a/lib/device_source_impl.h
+++ b/lib/device_source_impl.h
@@ -48,7 +48,6 @@ namespace gr {
 	     boost::condition_variable iio_cond, iio_cond2;
 	     unsigned long items_in_buffer;
 	     off_t byte_offset;
-	     unsigned long sample_counter;
 	     volatile bool please_refill_buffer, thread_stopped;
 	     pmt::pmt_t port_id;
 


### PR DESCRIPTION
If the flow runs for a long time, the sample counter value reaches the maximum value accepted by the unsigned long type (4 bytes), seeing how it gets reset only if the flow stops. If this happens, the tag which signals the "buffer_start" is no longer correctly added. 
In order to fix this issue, we can change the sample counter variable type from unsigned long to uint64_t. This should not affect the general behaviour. Also, the gnuradio tag_t structure documentation states that the offset should be uint64_t.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>