### PR TITLE
Fix building with GNU Radio 3.8

### DIFF
--- a/lib/iio_math_gen_impl.cc
+++ b/lib/iio_math_gen_impl.cc
@@ -27,8 +27,11 @@
 #include <cmath>
 
 #include "iio_math_impl.h"
-
+#ifdef GR_VERSION_3_7_OR_LESS
 #include <gnuradio/analog/sig_source_f.h>
+#else
+#include <gnuradio/analog/sig_source.h>
+#endif
 #include <gnuradio/analog/sig_source_waveform.h>
 #include <gnuradio/io_signature.h>
 

--- a/lib/iio_math_impl.cc
+++ b/lib/iio_math_impl.cc
@@ -26,16 +26,24 @@
 #include "iio_math_impl.h"
 
 #include <boost/lexical_cast.hpp>
-
+#ifdef GR_VERSION_3_7_OR_LESS
 #include <gnuradio/analog/sig_source_f.h>
-#include <gnuradio/analog/sig_source_waveform.h>
 #include <gnuradio/blocks/add_ff.h>
-#include <gnuradio/blocks/copy.h>
 #include <gnuradio/blocks/divide_ff.h>
 #include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/blocks/multiply_ff.h>
-#include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/blocks/sub_ff.h>
+#else
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/blocks/add_blk.h>
+#include <gnuradio/blocks/divide.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/blocks/sub.h>
+#endif
+#include <gnuradio/analog/sig_source_waveform.h>
+#include <gnuradio/blocks/copy.h>
+#include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/blocks/transcendental.h>
 #include <gnuradio/iio/modulo_ff.h>
 #include <gnuradio/iio/power_ff.h>


### PR DESCRIPTION
Fix building with the current ```next``` branch of the GNU Radio upstream repository, which eventually will become version 3.8. This change does not break backward compatibility with former versions of GNU Radio.