### PR TITLE
Enable scientific notation in GRC block masks

### DIFF
--- a/grc/iio_fmcomms2_sink.xml
+++ b/grc/iio_fmcomms2_sink.xml
@@ -5,8 +5,8 @@
 	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
-	<make>iio.fmcomms2_sink_f32c($uri, $frequency, $samplerate, $bandwidth, $tx1_en, $tx2_en, $buffer_size, $cyclic, $rf_port_select, $attenuation1, $attenuation2, $filter, $auto_filter)</make>
-	<callback>set_params($frequency, $samplerate, $bandwidth, $rf_port_select, $attenuation1, $attenuation2, $filter, $auto_filter)</callback>
+	<make>iio.fmcomms2_sink_f32c($uri, int($frequency), int($samplerate), int($bandwidth), $tx1_en, $tx2_en, $buffer_size, $cyclic, $rf_port_select, $attenuation1, $attenuation2, $filter, $auto_filter)</make>
+	<callback>set_params(int($frequency), int($samplerate), int($bandwidth), $rf_port_select, $attenuation1, $attenuation2, $filter, $auto_filter)</callback>
 
 	<param>
 		<name>IIO context URI</name>
@@ -19,21 +19,21 @@
 		<name>LO Frequency</name>
 		<key>frequency</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>Sample rate</name>
 		<key>samplerate</key>
 		<value>2084000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>RF bandwidth</name>
 		<key>bandwidth</key>
 		<value>20000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
@@ -119,6 +119,11 @@
 
 	<!-- if we're below 2.084 MSPS, we require either a user-supplied filter, or the auto filter. -->
 	<check>($samplerate &gt;= 2084000) or (len($filter) &gt; 0) or $auto_filter</check>
+
+	<!-- Can't have negative values for curtain parameters. -->
+	<check>($frequency &gt;= 0)</check>
+	<check>($bandwidth &gt;= 0)</check>
+	<check>($samplerate &gt;= 0)</check>
 
 	<!-- We can't enable user-supplied filter and auto-filter at the same time. -->
 	<check>not ($auto_filter and len($filter))</check>

--- a/grc/iio_fmcomms2_source.xml
+++ b/grc/iio_fmcomms2_source.xml
@@ -5,8 +5,8 @@
 	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
-	<make>iio.fmcomms2_source_f32c($uri, $frequency, $samplerate, $bandwidth, $rx1_en, $rx2_en, $buffer_size, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $rf_port_select, $filter, $auto_filter)</make>
-	<callback>set_params($frequency, $samplerate, $bandwidth, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $rf_port_select, $filter, $auto_filter)</callback>
+	<make>iio.fmcomms2_source_f32c($uri, int($frequency), int($samplerate), int($bandwidth), $rx1_en, $rx2_en, $buffer_size, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $rf_port_select, $filter, $auto_filter)</make>
+	<callback>set_params(int($frequency), int($samplerate), int($bandwidth), $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $rf_port_select, $filter, $auto_filter)</callback>
 
 	<param>
 		<name>IIO context URI</name>
@@ -19,21 +19,21 @@
 		<name>LO Frequency</name>
 		<key>frequency</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>Sample rate</name>
 		<key>samplerate</key>
 		<value>2084000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>RF bandwidth</name>
 		<key>bandwidth</key>
 		<value>20000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
@@ -222,6 +222,11 @@
 
 	<!-- if we're below 2.084 MSPS, we require either a user-supplied filter, or the auto filter. -->
 	<check>($samplerate &gt;= 2084000) or (len($filter) &gt; 0) or $auto_filter</check>
+
+	<!-- Can't have negative values for curtain parameters. -->
+	<check>($frequency &gt;= 0)</check>
+	<check>($bandwidth &gt;= 0)</check>
+	<check>($samplerate &gt;= 0)</check>
 
 	<!-- We can't enable user-supplied filter and auto-filter at the same time. -->
 	<check>not ($auto_filter and len($filter))</check>

--- a/grc/iio_fmcomms5_sink.xml
+++ b/grc/iio_fmcomms5_sink.xml
@@ -5,8 +5,9 @@
 	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
-	<make>iio.fmcomms5_sink_f32c($uri, $frequency1, $frequency2, $samplerate, $bandwidth, $ch1_en, $ch2_en, $ch3_en, $ch4_en, $buffer_size, $cyclic, $rf_port_select, $attenuation1, $attenuation2, $attenuation3, $attenuation4, $filter)</make>
-	<callback>set_params($frequency, $samplerate, $bandwidth, $rf_port_select, $attenuation1, $attenuation2)</callback>
+	<make>iio.fmcomms5_sink_f32c($uri, int($frequency1), int($frequency2), int($samplerate), int($bandwidth), $ch1_en, $ch2_en, $ch3_en, $ch4_en, $buffer_size, $cyclic, $rf_port_select, $attenuation1, $attenuation2, $attenuation3, $attenuation4, $filter)</make>
+	<callback>set_params(int($frequency1), int($frequency2), int($samplerate), int($bandwidth), $rf_port_select, $attenuation1, $attenuation2, $attenuation3, $attenuation4)</callback>
+
 
 	<param>
 		<name>IIO context URI</name>
@@ -19,28 +20,28 @@
 		<name>LO Frequency (TX1/TX2)</name>
 		<key>frequency1</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>LO Frequency (TX3/TX4)</name>
 		<key>frequency2</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>Sample rate</name>
 		<key>samplerate</key>
 		<value>2084000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>RF bandwidth</name>
 		<key>bandwidth</key>
 		<value>20000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
@@ -146,6 +147,12 @@
 
 	<check>sum([$ch1_en, $ch2_en, $ch3_en, $ch4_en]) &gt; 0</check>
 	<check>$samplerate &gt;= 2084000</check>
+
+	<!-- Can't have negative values for curtain parameters. -->
+	<check>($frequency1 &gt;= 0)</check>
+	<check>($frequency2 &gt;= 0)</check>
+	<check>($bandwidth &gt;= 0)</check>
+	<check>($samplerate &gt;= 0)</check>
 
 	<sink>
 		<name>in</name>

--- a/grc/iio_fmcomms5_source.xml
+++ b/grc/iio_fmcomms5_source.xml
@@ -5,8 +5,8 @@
 	<category>[Industrial IO]/FMComms</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
-	<make>iio.fmcomms5_source_f32c($uri, $frequency1, $frequency2, $samplerate, $bandwidth, $ch1_en, $ch2_en, $ch3_en, $ch4_en, $buffer_size, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $gain3, $manual_gain3, $gain4, $manual_gain4, $rf_port_select, $filter)</make>
-	<callback>set_params($frequency1, $frequency2, $samplerate, $bandwidth, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $gain3, $manual_gain3, $gain4, $manual_gain4, $rf_port_select)</callback>
+	<make>iio.fmcomms5_source_f32c($uri, int($frequency1), int($frequency2), int($samplerate), int($bandwidth), $ch1_en, $ch2_en, $ch3_en, $ch4_en, $buffer_size, $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $gain3, $manual_gain3, $gain4, $manual_gain4, $rf_port_select, $filter)</make>
+	<callback>set_params(int($frequency1), int($frequency2), int($samplerate), int($bandwidth), $quadrature, $rfdc, $bbdc, $gain1, $manual_gain1, $gain2, $manual_gain2, $gain3, $manual_gain3, $gain4, $manual_gain4, $rf_port_select)</callback>
 
 	<param>
 		<name>IIO context URI</name>
@@ -19,28 +19,28 @@
 		<name>LO Frequency (RX1/RX2)</name>
 		<key>frequency1</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>LO Frequency (RX3/RX4)</name>
 		<key>frequency2</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>Sample rate</name>
 		<key>samplerate</key>
 		<value>2084000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>RF bandwidth</name>
 		<key>bandwidth</key>
 		<value>20000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
@@ -296,6 +296,12 @@
 
 	<check>sum([$ch1_en, $ch2_en, $ch3_en, $ch4_en]) &gt; 0</check>
 	<check>$samplerate &gt;= 2084000</check>
+
+	<!-- Can't have negative values for curtain parameters. -->
+	<check>($frequency1 &gt;= 0)</check>
+	<check>($frequency2 &gt;= 0)</check>
+	<check>($bandwidth &gt;= 0)</check>
+	<check>($samplerate &gt;= 0)</check>
 
 	<source>
 		<name>out</name>

--- a/grc/iio_pluto_sink.xml
+++ b/grc/iio_pluto_sink.xml
@@ -5,8 +5,8 @@
 	<category>[Industrial IO]/PlutoSDR</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
-	<make>iio.pluto_sink($uri, $frequency, $samplerate, $bandwidth, $buffer_size, $cyclic, $attenuation, $filter, $auto_filter)</make>
-	<callback>set_params($frequency, $samplerate, $bandwidth, $attenuation, $filter, $auto_filter)</callback>
+	<make>iio.pluto_sink($uri, int($frequency), int($samplerate), int($bandwidth), $buffer_size, $cyclic, $attenuation, $filter, $auto_filter)</make>
+	<callback>set_params(int($frequency), int($samplerate), int($bandwidth), $attenuation, $filter, $auto_filter)</callback>
 
 	<param>
 		<name>IIO context URI</name>
@@ -19,21 +19,21 @@
 		<name>LO Frequency</name>
 		<key>frequency</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>Sample rate</name>
 		<key>samplerate</key>
 		<value>2084000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>RF bandwidth</name>
 		<key>bandwidth</key>
 		<value>20000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
@@ -77,6 +77,11 @@
 
 	<!-- if we're below 2.084 MSPS, we require either a user-supplied filter, or the auto filter. -->
 	<check>($samplerate &gt;= 2084000) or (len($filter) &gt; 0) or $auto_filter</check>
+
+	<!-- Can't have negative values for curtain parameters. -->
+	<check>($frequency &gt;= 0)</check>
+	<check>($bandwidth &gt;= 0)</check>
+	<check>($samplerate &gt;= 0)</check>
 
 	<!-- We can't enable user-supplied filter and auto-filter at the same time. -->
 	<check>not ($auto_filter and len($filter))</check>

--- a/grc/iio_pluto_source.xml
+++ b/grc/iio_pluto_source.xml
@@ -5,8 +5,8 @@
 	<category>[Industrial IO]/PlutoSDR</category>
 	<flags>throttle</flags>
 	<import>from gnuradio import iio</import>
-	<make>iio.pluto_source($uri, $frequency, $samplerate, $bandwidth, $buffer_size, $quadrature, $rfdc, $bbdc, $gain, $manual_gain, $filter, $auto_filter)</make>
-	<callback>set_params($frequency, $samplerate, $bandwidth, $quadrature, $rfdc, $bbdc, $gain, $manual_gain, $filter, $auto_filter)</callback>
+	<make>iio.pluto_source($uri, int($frequency), int($samplerate), int($bandwidth), $buffer_size, $quadrature, $rfdc, $bbdc, $gain, $manual_gain, $filter, $auto_filter)</make>
+	<callback>set_params(int($frequency), int($samplerate), int($bandwidth), $quadrature, $rfdc, $bbdc, $gain, $manual_gain, $filter, $auto_filter)</callback>
 
 	<param>
 		<name>Device URI</name>
@@ -19,21 +19,21 @@
 		<name>LO Frequency</name>
 		<key>frequency</key>
 		<value>2400000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>Sample rate</name>
 		<key>samplerate</key>
 		<value>2084000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
 		<name>RF bandwidth</name>
 		<key>bandwidth</key>
 		<value>20000000</value>
-		<type>int</type>
+		<type>real</type>
 	</param>
 
 	<param>
@@ -118,6 +118,11 @@
 
 	<!-- if we're below 2.084 MSPS, we require either a user-supplied filter, or the auto filter. -->
 	<check>($samplerate &gt;= 2084000) or (len($filter) &gt; 0) or $auto_filter</check>
+
+	<!-- Can't have negative values for curtain parameters. -->
+	<check>($frequency &gt;= 0)</check>
+	<check>($bandwidth &gt;= 0)</check>
+	<check>($samplerate &gt;= 0)</check>
 
 	<!-- We can't enable user-supplied filter and auto-filter at the same time. -->
 	<check>not ($auto_filter and len($filter))</check>


### PR DESCRIPTION
Fixes #36 for Pluto and FMComms boards.

Signed-off-by: Travis Collins <travis.collins@analog.com>