### PR TITLE
before_install_darwin: Keep Boost at version 1.67.

### DIFF
--- a/ci/travis/before_install_darwin
+++ b/ci/travis/before_install_darwin
@@ -3,8 +3,10 @@
 . ci/travis/lib.sh
 . ci/travis/before_install_lib.sh
 
-brew_install_or_upgrade cmake boost bison libusb libxml2 python@2 brew-pip \
+brew_install_or_upgrade cmake bison libusb libxml2 python@2 brew-pip \
 	fftw flex
+# keep the old boost version for now
+brew switch boost 1.67.0_1
 
 for pkg in gcc bison gettext ; do
 	brew link --overwrite --force $pkg


### PR DESCRIPTION
For boost 1.70 there are some changes required for the tcp_connection. 
A fix for this was introduced in the mainline GNURadio ( see here: https://github.com/gnuradio/gnuradio/pull/2500/commits/6dc8229fd0dda25c054c2194ee2c9b28affe92d8 ), but we are still using the analogdevicesinc fork ( https://github.com/analogdevicesinc/gr-iio/blob/master/ci/travis/before_install_lib.sh#L126). 
When we switch to the official repo, we can remove the boost restriction.


Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>