### PR TITLE
.travis.yml: force xenial for docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ matrix:
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
+      # FIXME: remove dist, when Xenial images become default in Travis CI
+      dist: xenial
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=7
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
+      # FIXME: remove dist, when Xenial images become default in Travis CI
+      dist: xenial
       env:
         - OS_TYPE=ubuntu_docker
         - OS_VERSION=bionic


### PR DESCRIPTION
Apparently, even though Travis-CI is moving to use Xenial (16.04) dockers,
some Trusty dockers are still lurking around and randomly being assigned to
builds.

For this repo in particular, Trusty seems to be allocated mostly.
Force Xenial, since that will be the next default docker image in a few
months. This fails because of `EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss`
where the build complains that:
```
sftp -oHostKeyAlgorithms=+ssh-dss [secure]@[secure]
command-line line 0: Bad protocol 2 host key algorithms '+ssh-dss'.
```

We could remove the EXTRA_SSH stuff in the build, but we'd get the error
that the EXTRA_SSH option is fixing.

So, just default to Xenial docker images (for docker builds), add a note
about it in the `.travis.yml` and change later. We will need to re-update
builds at some point in time anyway.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>