### PR TITLE
cmake,build: move boost chrono to all components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,9 @@ set(Boost_ADDITIONAL_VERSIONS
     "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
 )
 
-set(BOOST_REQUIRED_COMPONENTS filesystem system thread date_time)
+set(BOOST_REQUIRED_COMPONENTS filesystem system thread date_time chrono)
 
 if(MSVC)
-    set(BOOST_REQUIRED_COMPONENTS ${BOOST_REQUIRED_COMPONENTS} chrono)
-
     if (NOT DEFINED BOOST_ALL_DYN_LINK)
         set(BOOST_ALL_DYN_LINK TRUE)
     endif()


### PR DESCRIPTION
Recently, gr-iio builds have started to fail on OS X with:
```
Undefined symbols for architecture x86_64:
  "boost::chrono::steady_clock::now()", referenced from:
      void boost::this_thread::sleep_for<long long, boost::ratio<1l, 1000l> >(boost::chrono::duration<long long, boost::ratio<1l, 1000l> > const&) in attr_source_impl.cc.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This change moves the chrono boost component to be required by all archs.
At the moment Linux does not fail, but maybe later we might need to do it
as well.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>