### PR TITLE
Drop boost::chrono dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ install:
     - appveyor-retry nuget install boost_atomic-vc120 -Version 1.61.0
     - appveyor-retry nuget install boost_system-vc120 -Version 1.61.0
     - appveyor-retry nuget install boost_filesystem-vc120 -Version 1.61.0
-    - appveyor-retry nuget install boost_chrono-vc120 -Version 1.61.0
     - appveyor-retry nuget install boost_date_time-vc120 -Version 1.61.0
     - appveyor-retry nuget install boost_thread-vc120 -Version 1.61.0
 
@@ -54,7 +53,7 @@ build_script:
         -DBoost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=c:/boost_filesystem-vc120.1.61.0.0/lib/native/address-model-64/lib/boost_filesystem-vc120-mt-1_61.lib \
         -DBoost_THREAD_LIBRARY_RELEASE:FILEPATH=c:/boost_thread-vc120.1.61.0.0/lib/native/address-model-64/lib/boost_thread-vc120-mt-1_61.lib \
         -DBoost_SYSTEM_LIBRARY_RELEASE:FILEPATH=c:/boost_system-vc120.1.61.0.0/lib/native/address-model-64/lib/boost_system-vc120-mt-1_61.lib \
-        -DBoost_LIBRARY_DIR_RELEASE:PATH=c:/boost_chrono-vc120.1.61.0.0/lib/native/address-model-64/lib;c:/boost_date_time-vc120.1.61.0.0/lib/native/address-model-64/lib;c:/boost_thread-vc120.1.61.0.0/lib/native/address-model-64/lib;c:/boost_system-vc120.1.61.0.0/lib/native/address-model-64/lib;c:/boost_filesystem-vc120.1.61.0.0/lib/native/address-model-64/lib \
+        -DBoost_LIBRARY_DIR_RELEASE:PATH=c:/boost_date_time-vc120.1.61.0.0/lib/native/address-model-64/lib;c:/boost_thread-vc120.1.61.0.0/lib/native/address-model-64/lib;c:/boost_system-vc120.1.61.0.0/lib/native/address-model-64/lib;c:/boost_filesystem-vc120.1.61.0.0/lib/native/address-model-64/lib \
         -DSWIG_EXECUTABLE:FILEPATH=c:/swigwin-3.0.8/swig.exe \
         -DIIO_INCLUDE_DIRS:PATH=c:/libiio-win64 \
         -DIIO_LIBRARIES:FILEPATH=c:/libiio-win64/libiio.lib \

--- a/lib/attr_source_impl.cc
+++ b/lib/attr_source_impl.cc
@@ -26,8 +26,8 @@
 #include <gnuradio/io_signature.h>
 #include "attr_source_impl.h"
 #include <boost/lexical_cast.hpp>
-#include <boost/chrono.hpp>
-#include <boost/thread/thread.hpp>
+#include <chrono>
+#include <thread>
 #include <vector>
 
 
@@ -255,7 +255,7 @@ namespace gr {
 
       for (sample = 0; sample<samples_per_update; sample++)
       {
-        boost::this_thread::sleep_for(boost::chrono::milliseconds(update_interval_ms));
+        std::this_thread::sleep_for(std::chrono::milliseconds(update_interval_ms));
         if (attr_type == 3)
           get_register_data(address, ( ((int*) out)+sample) );
         else {


### PR DESCRIPTION
On Arch Linux (python 3.8.0 + gnuradio 3.8.0.0-5) running gr-iio based flowgraph result in following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/iio/__init__.py", line 30, in <module>
    from .iio_swig import *
  File "/usr/lib/python3.8/site-packages/iio/iio_swig.py", line 13, in <module>
    from . import _iio_swig
ImportError: /usr/lib/libgnuradio-iio.so...: undefined symbol: _ZN5boost6chrono12steady_clock3nowEv

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "file_tx.py", line 34, in <module>
    import iio
  File "/usr/lib/python3.8/site-packages/iio/__init__.py", line 36, in <module>
    from .iio_swig import *
  File "/usr/lib/python3.8/site-packages/iio/iio_swig.py", line 13, in <module>
    from . import _iio_swig
ImportError: /usr/lib/libgnuradio-iio.so...: undefined symbol: _ZN5boost6chrono12steady_clock3nowEv

```

This pull request drops `boost::chrono` in favor of using `std::chrono`, which fixed the error.
Tested on desktop archlinux (x86_64) + on ADRV9361-Z7035.