### PR TITLE
Remove extraneous parameters from Pluto sink/source callbacks

### DIFF
--- a/grc/iio_pluto_sink.block.yml
+++ b/grc/iio_pluto_sink.block.yml
@@ -66,6 +66,6 @@ templates:
     imports: import iio
     make: iio.pluto_sink(${uri}, ${frequency}, ${samplerate}, ${bandwidth}, ${buffer_size}, ${cyclic}, ${attenuation1}, ${filter}, ${auto_filter})
     callbacks:
-      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${buffer_size}, ${cyclic}, ${attenuation1}, ${filter}, ${auto_filter})
+      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${attenuation1}, ${filter}, ${auto_filter})
 
 file_format: 1

--- a/grc/iio_pluto_source.block.yml
+++ b/grc/iio_pluto_source.block.yml
@@ -88,6 +88,6 @@ templates:
     imports: import iio
     make: iio.pluto_source(${uri}, ${frequency}, ${samplerate}, ${bandwidth}, ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${filter}, ${auto_filter})
     callbacks:
-      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${filter}, ${auto_filter})
+      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${filter}, ${auto_filter})
 
 file_format: 1


### PR DESCRIPTION
Make sure that the callback parameters in the YAML files correspond to their C++ implementations to avoid runtime errors.