### PR TITLE
Fix grc install destination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ set(GR_PKG_DATA_DIR     ${GR_DATA_DIR}/${CMAKE_PROJECT_NAME})
 set(GR_PKG_DOC_DIR      ${GR_DOC_DIR}/${CMAKE_PROJECT_NAME})
 set(GR_PKG_CONF_DIR     ${GR_CONF_DIR}/${CMAKE_PROJECT_NAME}/conf.d)
 set(GR_PKG_LIBEXEC_DIR  ${GR_LIBEXEC_DIR}/${CMAKE_PROJECT_NAME})
+set(GRC_BLOCKS_DIR      ${GR_PKG_DATA_DIR}/grc/blocks)
 
 ########################################################################
 # Find gnuradio build dependencies


### PR DESCRIPTION
Fix grc install destination because GRC_BLOCKS_DIR is no longer defined in the top-level CMakeLists.txt

NOTE:
a successful CMake configuration requires this fix to FindLOG4CPP.cmake in GNURadio 3.8: https://github.com/gnuradio/gnuradio/commit/12de35d23071fe957ed78078fcbda99d2fc38207