### PR TITLE
CMakeLists.txt: Changed the destination directory of the include files

### DIFF
--- a/include/iio/CMakeLists.txt
+++ b/include/iio/CMakeLists.txt
@@ -30,5 +30,5 @@ install(FILES
 	attr_sink.h
 	attr_source.h
 	modulo_ff.h modulo_const_ff.h
-	DESTINATION ${GR_INCLUDE_DIR}/iio
+	DESTINATION ${GR_INCLUDE_DIR}
 )


### PR DESCRIPTION
When including gr-iio headers in an external app, you have to
#include <iio/iio/device_sync.h> while internal includes
refer to the same file using #include <iio/device_sync.h>
This commit changes the destination of the include files on make install
so the external app includes just <iio/device_sync.h>

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>