### PR TITLE
Changed block's category "Core" to "Industrial IO".

### DIFF
--- a/grc/iio.tree.yml
+++ b/grc/iio.tree.yml
@@ -1,16 +1,15 @@
-'[Core]':
-- 'Industrial I/O':
-  - 'Generic':
-    - iio_device_source
-    - iio_device_sink
-    - iio_attr_source
-    - iio_attr_sink
-    - iio_attr_updater
-  - 'FMComms':
-    - iio_fmcomms2_source
-    - iio_fmcomms2_sink
-    - iio_fmcomms5_source
-    - iio_fmcomms5_sink
-  - 'PlutoSDR':
-    - iio_pluto_source
-    - iio_pluto_sink
+'[Industrial IO]':
+- 'Generic':
+  - iio_device_source
+  - iio_device_sink
+  - iio_attr_source
+  - iio_attr_sink
+  - iio_attr_updater
+- 'FMComms':
+  - iio_fmcomms2_source
+  - iio_fmcomms2_sink
+  - iio_fmcomms5_source
+  - iio_fmcomms5_sink
+- 'PlutoSDR':
+  - iio_pluto_source
+  - iio_pluto_sink


### PR DESCRIPTION
I'm using a ADALM-Pluto in Windows Subsystem Linux 2.
I tried to build "gr-iio" block at V3.8(Ubuntu20.04 @ WSL2), and it was successed.
But I could not find pluto's blocks.
When V3.7, the blocks are located the top of tree.
I searched the blocks for a short while, finally, I found the blocks under the "Core" category.
So I think it's better to modify "iio.tree.yml " to make it the same as the previous version.

![Changed block's category Core to Industrial IO](https://user-images.githubusercontent.com/11815644/97803108-3f1f9b80-1c8b-11eb-87aa-16cb27a1b1e3.png)
