### PR TITLE
Fix compile error using recent versions of Boost

### DIFF
--- a/lib/attr_sink_impl.cc
+++ b/lib/attr_sink_impl.cc
@@ -89,7 +89,7 @@ namespace gr {
       }
 
       message_port_register_in(pmt::mp("attr"));
-      set_msg_handler(pmt::mp("attr"), boost::bind(&attr_sink_impl::write_attribute, this, _1));
+      set_msg_handler(pmt::mp("attr"), boost::bind(&attr_sink_impl::write_attribute, this, boost::placeholders::_1));
 
     }
 


### PR DESCRIPTION
The placeholder constant "_1" is no longer defined in this scope and should be referenced using "boost::placeholders::_1" instead. 

This in particular relates to compiling on Fedora 33, where the build fails without this change.