### PR TITLE
Upgrade 3.8

### DIFF
--- a/grc/iio_fmcomms2_sink.block.yml
+++ b/grc/iio_fmcomms2_sink.block.yml
@@ -10,17 +10,17 @@ parameters:
 
 -   id: frequency
     label: LO Frequency
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: samplerate
     label: Sample Rate
-    dtype: int
+    dtype: real
     default: 2084000
 
 -   id: bandwidth
     label: RF Bandwidth
-    dtype: int
+    dtype: real
     default: 20000000
 
 -   id: buffer_size
@@ -94,8 +94,8 @@ asserts:
 
 templates:
     imports: import iio
-    make: iio.fmcomms2_sink_f32c(${uri}, ${frequency}, ${samplerate}, ${bandwidth}, ${tx1_en}, ${tx2_en}, ${buffer_size}, ${cyclic}, ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${filter}, ${auto_filter})
+    make: iio.fmcomms2_sink_f32c(${uri}, int(${frequency}), int(${samplerate}), int(${bandwidth}), ${tx1_en}, ${tx2_en}, ${buffer_size}, ${cyclic}, ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${filter}, ${auto_filter})
     callbacks:
-      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${filter}, ${auto_filter})
+      - set_params(int(${frequency}), int(${samplerate}), int(${bandwidth}), ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${filter}, ${auto_filter})
 
 file_format: 1

--- a/grc/iio_fmcomms2_source.block.yml
+++ b/grc/iio_fmcomms2_source.block.yml
@@ -10,17 +10,17 @@ parameters:
 
 -   id: frequency
     label: LO Frequency
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: samplerate
     label: Sample Rate
-    dtype: int
+    dtype: real
     default: 2084000
 
 -   id: bandwidth
     label: RF Bandwidth
-    dtype: int
+    dtype: real
     default: 20000000
 
 -   id: buffer_size
@@ -125,8 +125,8 @@ asserts:
 
 templates:
     imports: import iio
-    make: iio.fmcomms2_source_f32c(${uri}, ${frequency}, ${samplerate}, ${bandwidth}, ${rx1_en}, ${rx2_en}, ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${rf_port_select}, ${filter}, ${auto_filter})
+    make: iio.fmcomms2_source_f32c(${uri}, int(${frequency}), int(${samplerate}), int(${bandwidth}), ${rx1_en}, ${rx2_en}, ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${rf_port_select}, ${filter}, ${auto_filter})
     callbacks:
-      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${rf_port_select}, ${filter}, ${auto_filter})
+      - set_params(int(${frequency}), int(${samplerate}), int(${bandwidth}), ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${rf_port_select}, ${filter}, ${auto_filter})
 
 file_format: 1

--- a/grc/iio_fmcomms5_sink.block.yml
+++ b/grc/iio_fmcomms5_sink.block.yml
@@ -10,22 +10,22 @@ parameters:
 
 -   id: frequency1
     label: LO Frequency (RX1/RX2)
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: frequency2
     label: LO Frequency (RX3/RX4)
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: samplerate
     label: Sample Rate
-    dtype: int
+    dtype: real
     default: 2084000
 
 -   id: bandwidth
     label: RF Bandwidth
-    dtype: int
+    dtype: real
     default: 20000000
 
 -   id: buffer_size
@@ -119,8 +119,8 @@ asserts:
 
 templates:
     imports: import iio
-    make: iio.fmcomms5_sink_f32c(${uri}, ${frequency1}, ${frequency2}, ${samplerate}, ${bandwidth}, ${tx1_en}, ${tx2_en}, ${tx3_en}, ${tx4_en}, ${buffer_size}, ${cyclic}, ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${attenuation3}, ${attenuation4}, ${filter})
+    make: iio.fmcomms5_sink_f32c(${uri}, int(${frequency1}), int(${frequency2}), int(${samplerate}), int(${bandwidth}), ${tx1_en}, ${tx2_en}, ${tx3_en}, ${tx4_en}, ${buffer_size}, ${cyclic}, ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${attenuation3}, ${attenuation4}, ${filter})
     callbacks:
-    - set_params(${frequency1}, ${frequency2}, ${samplerate}, ${bandwidth}, ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${attenuation3}, ${attenuation4})
+    - set_params(int(${frequency1}), int(${frequency2}), int(${samplerate}), int(${bandwidth}), ${rf_port_select}, ${attenuation1}, ${attenuation2}, ${attenuation3}, ${attenuation4})
 
 file_format: 1

--- a/grc/iio_fmcomms5_source.block.yml
+++ b/grc/iio_fmcomms5_source.block.yml
@@ -10,22 +10,22 @@ parameters:
 
 -   id: frequency1
     label: LO Frequency (RX1/RX2)
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: frequency2
     label: LO Frequency (RX3/RX4)
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: samplerate
     label: Sample Rate
-    dtype: int
+    dtype: real
     default: 2084000
 
 -   id: bandwidth
     label: RF Bandwidth
-    dtype: int
+    dtype: real
     default: 20000000
 
 -   id: buffer_size
@@ -166,8 +166,8 @@ asserts:
 
 templates:
     imports: import iio
-    make: iio.fmcomms5_source_f32c(${uri}, ${frequency1}, ${frequency2}, ${samplerate}, ${bandwidth}, ${rx1_en}, ${rx2_en}, ${rx3_en}, ${rx4_en}, ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${gain3}, ${manual_gain3}, ${gain4}, ${manual_gain4}, ${rf_port_select}, ${filter})
+    make: iio.fmcomms5_source_f32c(${uri}, int(${frequency1}), int(${frequency2}), int(${samplerate}), int(${bandwidth}), ${rx1_en}, ${rx2_en}, ${rx3_en}, ${rx4_en}, ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${gain3}, ${manual_gain3}, ${gain4}, ${manual_gain4}, ${rf_port_select}, ${filter})
     callbacks:
-    - set_params(${frequency1}, ${frequency2}, ${samplerate}, ${bandwidth}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${gain3}, ${manual_gain3}, ${gain4}, ${manual_gain4}, ${rf_port_select})
+    - set_params(int(${frequency1}), int(${frequency2}), int(${samplerate}), int(${bandwidth}), ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${gain2}, ${manual_gain2}, ${gain3}, ${manual_gain3}, ${gain4}, ${manual_gain4}, ${rf_port_select})
 
 file_format: 1

--- a/grc/iio_pluto_sink.block.yml
+++ b/grc/iio_pluto_sink.block.yml
@@ -10,17 +10,17 @@ parameters:
 
 -   id: frequency
     label: LO Frequency
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: samplerate
     label: Sample Rate
-    dtype: int
+    dtype: real
     default: 2084000
 
 -   id: bandwidth
     label: RF Bandwidth
-    dtype: int
+    dtype: real
     default: 20000000
 
 -   id: buffer_size
@@ -64,8 +64,8 @@ asserts:
 
 templates:
     imports: import iio
-    make: iio.pluto_sink(${uri}, ${frequency}, ${samplerate}, ${bandwidth}, ${buffer_size}, ${cyclic}, ${attenuation1}, ${filter}, ${auto_filter})
+    make: iio.pluto_sink(${uri}, int(${frequency}), int(${samplerate}), int(${bandwidth}), ${buffer_size}, ${cyclic}, ${attenuation1}, ${filter}, ${auto_filter})
     callbacks:
-      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${attenuation1}, ${filter}, ${auto_filter})
+      - set_params(int(${frequency}), int(${samplerate}), int({bandwidth}), ${attenuation1}, ${filter}, ${auto_filter})
 
 file_format: 1

--- a/grc/iio_pluto_source.block.yml
+++ b/grc/iio_pluto_source.block.yml
@@ -10,17 +10,17 @@ parameters:
 
 -   id: frequency
     label: LO Frequency
-    dtype: int
+    dtype: real
     default: 2400000000
 
 -   id: samplerate
     label: Sample Rate
-    dtype: int
+    dtype: real
     default: 2084000
 
 -   id: bandwidth
     label: RF Bandwidth
-    dtype: int
+    dtype: real
     default: 20000000
 
 -   id: buffer_size
@@ -86,8 +86,8 @@ asserts:
 
 templates:
     imports: import iio
-    make: iio.pluto_source(${uri}, ${frequency}, ${samplerate}, ${bandwidth}, ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${filter}, ${auto_filter})
+    make: iio.pluto_source(${uri}, int(${frequency}), int(${samplerate}), int(${bandwidth}), ${buffer_size}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${filter}, ${auto_filter})
     callbacks:
-      - set_params(${frequency}, ${samplerate}, ${bandwidth}, ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${filter}, ${auto_filter})
+      - set_params(int(${frequency}), int(${samplerate}), int(${bandwidth}), ${quadrature}, ${rfdc}, ${bbdc}, ${gain1}, ${manual_gain1}, ${filter}, ${auto_filter})
 
 file_format: 1


### PR DESCRIPTION
Previous, xml-based, versions of gr-iio recieved scientific notation support with PR #36 . Were these changes lost or abandoned with the 3.8 upgrade? This PR migrates these changes to updated yaml files for scientific notation support with gr3.8.